### PR TITLE
Add more compiler runtime checks and enable by default also in Release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 
 set(ARCH_CUSTOM "" CACHE STRING "Name of custom architecture configuration to use")
 option(OPTIMIZE_C "Optimize C code even in Debug mode" ON)
+option(DISABLE_RUNTIME_CHECKS "Disable compiler runtime checks in Release mode" OFF)
 option(DEBUG_ARCH "Print arch files debug information" OFF)
 option(DEBUG_GLOBAL_DEFINITIONS "Print global preprocessor definitions applied to all source files" OFF)
 option(DEBUG_FEATURE_TESTS "Print debug information while running compiler feature tests" OFF)
@@ -163,6 +164,11 @@ set(CMAKE_Fortran_FLAGS "${Fortran_preprocess} ${Fortran_io} ${Fortran_other}")
 
 if (OPTIMIZE_C)
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${C_optimized}")
+endif()
+
+if (NOT DISABLE_RUNTIME_CHECKS)
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${C_checked}")
+    set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} ${Fortran_checked}")
 endif()
 
 if (SAVE_TEMPS)

--- a/README_CMAKE_INSTALL.md
+++ b/README_CMAKE_INSTALL.md
@@ -56,6 +56,7 @@ By default WRF-CMake will compile in `serial` mode with `basic` nesting option. 
 |`MODE`|`serial`, `dmpar`, `smpar`, `dm+sm`|`serial`|Serial/parallel modes|
 |`NESTING`|`none`, `basic`, `vortex`, `following`|`basic`|Domain Options|
 |`CMAKE_BUILD_TYPE`|`Release`, `Debug`|`Release`|Whether to optimise/build with debug flags.|
+|`DISABLE_RUNTIME_CHECKS`|`ON`, `OFF`|`OFF`|Whether to disable compiler runtime checks in Release mode.|
 |`ENABLE_GRIB1`|`ON`, `OFF`|`ON`|Enable/Disable GRIB 1 support.|
 |`ENABLE_GRIB2`|`ON`, `OFF`|`ON`|Enable/Disable GRIB 2 support.|
 

--- a/README_CMAKE_INSTALL.md
+++ b/README_CMAKE_INSTALL.md
@@ -87,6 +87,7 @@ where `<install_directory>` is the directory where to install WPS and `<wrf_cmak
 |Name|Options|Default|Description|
 |----|-------|-------|-----------|
 |`CMAKE_BUILD_TYPE`|`Release`, `Debug`|`Release`|Whether to optimise/build with debug flags.|
+|`DISABLE_RUNTIME_CHECKS`|`ON`, `OFF`|`OFF`|Whether to disable compiler runtime checks in Release mode.|
 |`ENABLE_GRIB1`|`ON`, `OFF`|`OFF`|Enable/Disable GRIB 1 support (`ungrib` always has GRIB 1).|
 |`ENABLE_GRIB2_PNG`|`ON`, `OFF`|`ON`|Enable/Disable GRIB 2 PNG support.|
 |`ENABLE_GRIB2_JPEG2000`|`ON`, `OFF`|`ON`|Enable/Disable GRIB 2 JPEG2000 support.|

--- a/cmake/arch/default/GNU_Fortran.cmake
+++ b/cmake/arch/default/GNU_Fortran.cmake
@@ -1,6 +1,6 @@
 # Copyright 2018 M. Riechert and D. Meyer. Licensed under the MIT License.
 
-set(checked "-fbounds-check")
+set(checked "-fcheck=bounds,do,mem,pointer")
 set(preprocess "-cpp")
 set(io "-fconvert=big-endian -frecord-marker=4")
 set(other "-ffree-line-length-none")

--- a/cmake/arch/default/Intel_Fortran_UNIX.cmake
+++ b/cmake/arch/default/Intel_Fortran_UNIX.cmake
@@ -1,6 +1,6 @@
 # Copyright 2018 M. Riechert and D. Meyer. Licensed under the MIT License.
 
-set(checked "-check bounds")
+set(checked "-check noarg_temp_created,bounds,format,output_conversion,pointers,uninit")
 set(preprocess "-fpp")
 set(io "-convert big_endian -assume byterecl")
 set(optimized "${optimized} -align all -fno-alias")


### PR DESCRIPTION
The idea is to catch more errors that may otherwise lead to nondeterministic output. Those errors may happen with invalid namelist files, in particular accessing an array out of bounds when the array index gets computed indirectly from namelist parameters and not enough checks in the code are in place to guard against invalid input.

Same change in WPS: https://github.com/WRF-CMake/WPS/pull/2