### PR TITLE
Add Clang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
       env:
         - BUILD_SYSTEM=CMake
         - BUILD_TYPE=Debug
-        - CC=gcc-8 # GNU via Homebrew
+        - CC=clang # Apple Clang
         - FC=gfortran-8
         - GRIB1=1
         - GRIB2=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,6 @@ if (NOT MINGW AND NOT UNIX)
     message(FATAL_ERROR "Unsupported operating system / toolset")
 endif()
 
-if (CMAKE_Fortran_COMPILER_ID MATCHES "Clang")
-    # See Transpose() subroutine in external/io_netcdf/wrf_io.F90 for details.
-    message(FATAL_ERROR "Clang is not supported, use gcc/gfortran from Homebrew instead")
-endif()
-
 if (NOT ARCH_CUSTOM)
     set(ARCH_C_VARS debug optimized checked temps other)
     set(ARCH_Fortran_VARS debug optimized preprocess io checked temps other)

--- a/cmake/arch/default/AppleClang_C.cmake
+++ b/cmake/arch/default/AppleClang_C.cmake
@@ -1,0 +1,6 @@
+# WRF-CMake (https://github.com/WRF-CMake/WRF).
+# Copyright 2018 M. Riechert and D. Meyer. Licensed under the MIT License.
+
+set(debug "-g")
+set(optimized "-O3")
+set(temps "-save-temps")

--- a/cmake/arch/default/Clang_C.cmake
+++ b/cmake/arch/default/Clang_C.cmake
@@ -1,0 +1,6 @@
+# WRF-CMake (https://github.com/WRF-CMake/WRF).
+# Copyright 2018 M. Riechert and D. Meyer. Licensed under the MIT License.
+
+set(debug "-g")
+set(optimized "-O3")
+set(temps "-save-temps")

--- a/external/io_netcdf/wrf_io.F90
+++ b/external/io_netcdf/wrf_io.F90
@@ -760,7 +760,7 @@ subroutine Transpose(IO,MemoryOrder,di, Field,l1,l2,m1,m2,n1,n2 &
 #ifdef NO_M4
 #if defined(__GFORTRAN__) || defined(_CRAYFTN)
 ! The following is taken from https://modelingguru.nasa.gov/docs/DOC-1932 and works on gfortran and Cray,
-! but not clang or Intel Fortran (inserts whitespaces).
+! but not Intel Fortran (inserts whitespaces).
 #define XDEX(A,B,C) (A-A/**/1+1+(A/**/2-A/**/1+1)*((B-B/**/1)+(C-C/**/1)*(B/**/2-B/**/1+1)))
 #else
 ! The following works on Intel Fortran and preprocessors which have modern features enabled.


### PR DESCRIPTION
In this past we explicitly disabled Clang support due to some issue with the preprocessor. I tested it again with upstream Clang on Linux and Apple's Clang on macOS and there were no issues. Hence, this PR removes the check in the CMake script and adds the missing compiler configs for C. Note that two Clang configurations are needed, one named "Clang", the other "AppleClang", which is because CMake treats/identifies upstream Clang as different from Apple's Clang.