### PR TITLE
Add links to tutorials and general README clean up

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**System information (please complete the following information):**
+ - OS name and version: [e.g. Ubuntu 18, macOS 10.14, Windows 10]
+ - Compiler name and version [e.g. gcc/gfortran 8.1, icc/ifort 19]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request he

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,4 +14,4 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
-Add any other context or screenshots about the feature request he
+Add any other context or screenshots about the feature to be requested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,6 @@ In general, you can contribute by reporting an issue or by directly contributing
 - [Versioning](#versioning)
 
 
-If you would like to know more about specific development guidelines, please refer to our [development notes](DEVELOP.md).
-
 ## Report a bug
 
 Before creating bug reports, please check if similar issue have already been reported [here](https://github.com/WRF-CMake/WRF/issues). If none exist please create a new issue and include as many details as possible using the required template.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ Before creating a feature request, please check if a similar feature has been al
 
 ## Coding conventions
 
-Same as in the [WRF](https://github.com/wrf-model/WRF) and [WPS](https://github.com/wrf-model/WPS).
+Same as in [WRF](https://github.com/wrf-model/WRF) and [WPS](https://github.com/wrf-model/WPS).
 
 
 ## Versioning
 
-WRF-CMake and WPS-CMake fully tracks releases made by the [WRF](https://github.com/wrf-model/WRF) and [WPS](https://github.com/wrf-model/WPS) model.
+WRF-CMake and WPS-CMake fully tracks releases made by [WRF](https://github.com/wrf-model/WRF) and [WPS](https://github.com/wrf-model/WPS).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# How to contribute
+
+Thank you for considering contributing to the WRF-CMake project. Please note that the aim of WRF-CMake is to bring CMake support to WRF and WPS therefore, any contributions made to this project should only consist of changes/fixes to issues related to building WRF or WPS with CMake support, pre-built binaries, Homebrew/Linuxbrew support, and Continuous Integration (CI) and testing.
+
+For any issues/contributions related with the WRF or WPS model, please see the [WRF](https://github.com/wrf-model/WRF) and [WPS](https://github.com/wrf-model/WPS) repositories directly. For any question/issues with the model physics please refer to the [WRF/WRFDA/WRF-Chem/MPAS Users' Support Forum](http://forum.mmm.ucar.edu/phpBB3/).
+
+In general, you can contribute by reporting an issue or by directly contributing to the source code. For the latter, fork our repository, clone the fork, make your changes, and create a pull request (PR) with a **clear description** of your changes -- if you are unfamiliar about forking/creating PR, please see [this guide](https://guides.github.com/activities/forking/) first. If/when your changes are merged, you will appear as a [Contributors](https://github.com/WRF-CMake/WRF/graphs/contributors). For specific instructions on how to report a bug or how to submit a feature request, please see below:
+
+- [Report a bug](#report-a-bug)
+- [Request a new feature](#request-a-new-feature)
+- [Coding conventions](#coding-conventions)
+- [Versioning](#versioning)
+
+
+If you would like to know more about specific development guidelines, please refer to our [development notes](DEVELOP.md).
+
+## Report a bug
+
+Before creating bug reports, please check if similar issue have already been reported [here](https://github.com/WRF-CMake/WRF/issues). If none exist please create a new issue and include as many details as possible using the required template.
+
+## Request a new feature
+
+Before creating a feature request, please check if a similar feature has been already asked [here](https://github.com/WRF-CMake/WRF/issues). If none exist please create a new feature request and include as many details as possible using the required template.
+
+## Coding conventions
+
+Same as in the [WRF](https://github.com/wrf-model/WRF) and [WPS](https://github.com/wrf-model/WPS).
+
+
+## Versioning
+
+WRF-CMake and WPS-CMake fully tracks releases made by the [WRF](https://github.com/wrf-model/WRF) and [WPS](https://github.com/wrf-model/WPS) model.

--- a/README.md
+++ b/README.md
@@ -85,16 +85,16 @@ If you want to launch WRF-CMake and WPS-CMake built in `dmpar` to run on multipl
 
 ## Example usage
 
-If you are a complete beginner, we recommend going [trough the basics](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/Basics/index.php) or [running the case studies](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/CASES/index.php) as described in the [WRF-ARW Online Tutorial](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/).
+If you have already used WRF/WPS before and you just want a quick tutorial to go over the main steps, we have put together a very basic tutorial on our sister-project's website [GIS4WRF](https://gis4wrf.github.io/) with step-by-step instructions [here](https://gis4wrf.github.io/tutorials/wrf-cmake/simulate-the-2018-european-heat-wave-with-wrf-cmake/).
 
-If you have already used WRF/WPS before and you just want a quick tutorial to go over the main steps, we have put together a very basic one on our sister-project's website [GIS4WRF](https://gis4wrf.github.io/). You can follow the step-by-step tutorial [here](https://gis4wrf.github.io/tutorials/).
+Otherwise, if you are a complete beginner, we recommend going [trough the basics](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/Basics/index.php) or [running the case studies](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/CASES/index.php) as described in the [WRF-ARW Online Tutorial](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/).
 
 
 ## How to cite
 
 When using WRF-CMake in your project or publication, please cite the model as well as the software and version number as shown in the example below. Please make sure that you reference the correct DOI when referencing the software version you are using -- for a list of versions and corresponding DOIs, please see the archived versions on Zenodo at: [TODO]
 
-*We used WRF (Skamarock et al., 2008) model, from WRF-CMake (Riechert and Meyer, 2019a), version 4.1 (Riechert and Meyer, 2019b) to [...]*
+*We used the WRF (Skamarock et al., 2008) model WRF-CMake (Riechert and Meyer, 2019a), version 4.1 (Riechert and Meyer, 2019b) to [...]*
 
 The corresponding reference list should be as follows
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you want to launch WRF-CMake and WPS-CMake built in `dmpar` to run on multipl
 
 If you have already used WRF/WPS before and you just want a quick tutorial to go over the main steps, we have put together a very basic tutorial on our sister-project's website [GIS4WRF](https://gis4wrf.github.io/) with step-by-step instructions: [Simulate The 2018 European Heat Wave with WRF-CMake](https://gis4wrf.github.io/tutorials/wrf-cmake/simulate-the-2018-european-heat-wave-with-wrf-cmake/).
 
-Otherwise, if you are a beginner, we recommend going [trough the basics](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/Basics/index.php) or [running the case studies](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/CASES/index.php) as described in the [WRF-ARW Online Tutorial](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/).
+Otherwise, if you are a beginner, we recommend going [through the basics](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/Basics/index.php) or [running the case studies](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/CASES/index.php) as described in the [WRF-ARW Online Tutorial](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/).
 
 
 ## How to cite
@@ -99,9 +99,9 @@ When using WRF-CMake in your project or publication, please cite as shown in the
 
 The corresponding reference list should be as follows
 
-> Riechert and Meyer, 2019a: TODO
+> M. Riechert, D. Meyer, 2019a. TODO: *In preparation*
 >
-> Riechert and Meyer, 2019b: TODO
+> M. Riechert, D. Meyer, 2019b: TODO: *In preparation*
 >
 > W.C. Skamarock, J.B. Klemp, J. Dudhia, D.O. Gill, D.M. Barker, M.G. Duda, X.-Y. Huang, W. Wang, J.G. Powers
 **A Description of the Advanced Research WRF Version 3**. NCAR Tech (2008). Note NCAR/TN-475+STR. https://doi.org/10.5065/D68S4MVH

--- a/README.md
+++ b/README.md
@@ -93,18 +93,19 @@ Otherwise, if you are a beginner, we recommend going [through the basics](http:/
 
 ## How to cite
 
-When using WRF-CMake in your project or publication, please cite as shown in the example below -- both WRF-CMake and the WRF model should be cited. Please also make sure that you reference the correct DOI when referencing the software version you are using -- for a list of versions and corresponding DOIs, please see the archived versions on Zenodo at [TODO].
+When using WRF-CMake, please cite both model, and software (with version), e.g.:
 
-> We used WRF-CMake (Riechert and Meyer, 2019a), version x.x.x (Riechert and Meyer, 2019b) of the Weather Research and Forecasting (WRF) Model (Skamarock et al., 2008) to ...
+> We used the Weather Research and Forecasting (WRF) model (Skamarock et al., 2018) type WRF-CMake (Riechert and Meyer, 2019a), version x.x.x (Riechert and Meyer, 2019b) to ...
 
 The corresponding reference list should be as follows
 
-> M. Riechert, D. Meyer, 2019a. TODO: *In preparation*
+> Riechert, M., Meyer, D. (2019a). TODO: *In preparation*
 >
-> M. Riechert, D. Meyer, 2019b: TODO: *In preparation*
+> Riechert, M., Meyer, D. (2019b). TODO: *In preparation*
 >
-> W.C. Skamarock, J.B. Klemp, J. Dudhia, D.O. Gill, D.M. Barker, M.G. Duda, X.-Y. Huang, W. Wang, J.G. Powers
-**A Description of the Advanced Research WRF Version 3**. NCAR Tech (2008). Note NCAR/TN-475+STR. https://doi.org/10.5065/D68S4MVH
+> Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., Wang, W., et
+al. (2019). A description of the advanced research wrf model version 4 (p. 145). NCAR
+Technical Note NCAR/TN-556+STR. doi:10.5065/1dfh-6p97
 
 
 ## How to contribute

--- a/README.md
+++ b/README.md
@@ -92,18 +92,20 @@ Otherwise, if you are a complete beginner, we recommend going [trough the basics
 
 ## How to cite
 
-When using WRF-CMake in your project or publication, please cite the model as well as the software and version number as shown in the example below. Please make sure that you reference the correct DOI when referencing the software version you are using -- for a list of versions and corresponding DOIs, please see the archived versions on Zenodo at: [TODO]
+When using WRF-CMake in your project or publication, please cite as shown in the example below -- both WRF-CMake and the WRF model should be cited. Please also make sure that you reference the correct DOI when referencing the software version you are using -- for a list of versions and corresponding DOIs, please see the archived versions on Zenodo at [TODO].
 
-*We used the WRF (Skamarock et al., 2008) model WRF-CMake (Riechert and Meyer, 2019a), version 4.1 (Riechert and Meyer, 2019b) to [...]*
+> We used WRF-CMake (Riechert and Meyer, 2019a), version x.x.x (Riechert and Meyer, 2019b) of the Weather Research and Forecasting (WRF) Model (Skamarock et al., 2008) to ...
 
 The corresponding reference list should be as follows
 
-W.C. Skamarock, J.B. Klemp, J. Dudhia, D.O. Gill, D.M. Barker, M.G. Duda, X.-Y. Huang, W. Wang, J.G. Powers
+> Riechert and Meyer, 2019a: TODO
+>
+> Riechert and Meyer, 2019b: TODO
+>
+> W.C. Skamarock, J.B. Klemp, J. Dudhia, D.O. Gill, D.M. Barker, M.G. Duda, X.-Y. Huang, W. Wang, J.G. Powers
 **A Description of the Advanced Research WRF Version 3**. NCAR Tech (2008). Note NCAR/TN-475+STR. https://doi.org/10.5065/D68S4MVH
 
-Riechert and Meyer, 2019a: TODO
 
-Riechert and Meyer, 2019b: TODO
 
 
 ## Testing framework

--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
 # WRF-CMake [![Build status Azure Pipelines](https://dev.azure.com/WRF-CMake/WRF/_apis/build/status/WRF%20(full)?branchName=wrf-cmake)](https://dev.azure.com/WRF-CMake/WRF/_build/latest?definitionId=5&branchName=wrf-cmake) [![Build status Appveyor](https://ci.appveyor.com/api/projects/status/86508wximkvmf95g/branch/wrf-cmake?svg=true)](https://ci.appveyor.com/project/WRF-CMake/wrf/branch/wrf-cmake) [![Build status Travis CI](https://travis-ci.com/WRF-CMake/WRF.svg?branch=wrf-cmake)](https://travis-ci.com/WRF-CMake/WRF)
 
+  - [Project overview](#project-overview)
+    - [Currently supported platforms](#currently-supported-platforms)
+    - [Currently unsupported features](#currently-unsupported-features)
+  - [Installation](#installation)
+    - [Manually from source](#manually-from-source)
+    - [Using Homebrew or Linuxbrew](#using-homebrew-or-linuxbrew)
+    - [Binary distribution (Experimental)](#binary-distribution-experimental)
+  - [Documentation](#documentation)
+  - [Example usage](#example-usage)
+  - [How to cite](#how-to-cite)
+  - [Testing framework](#testing-framework)
+  - [Changes to be upstreamed](#changes-to-be-upstreamed)
+  - [Copyright and license](#copyright-and-license)
+
+## Project overview
+
 WRF-CMake adds CMake support to the latest version of the [Advanced Research Weather Research and Forecasting](https://www.mmm.ucar.edu/weather-research-and-forecasting-model) model (here WRF, for short) with the intention of streamlining and simplifying its configuration and build process. In our view, the use of CMake provides model developers, code maintainers, and end-users with several advantages such as robust incremental rebuilds, flexible library dependency discovery, native tool-chains for Windows, macOS, and Linux with minimal external dependencies, thus increasing portability, and automatic generation of project files for different platforms.
 
 WRF-CMake is designed to work alongside the current releases of WRF, therefore you can still compile your code using the legacy Makefiles included in WRF and WPS for any of the currently unsupported features.
 
+For more details, please see the short summary paper [WRF-CMake: integrating CMake support into the Advanced Research WRF (ARW) modelling system](https://joss.theoj.org/papers/9a87d84b2ed00ed82a6e297a4c34b3cf) on [The Journal of Open Source Software](https://joss.theoj.org/) website.
 
 ### Currently supported platforms
 
@@ -27,7 +44,21 @@ WRF-CMake is designed to work alongside the current releases of WRF, therefore y
 
 ## Installation
 
-The installation of WRF-CMake is straightforward thanks to the downloadable pre-built binaries for most Linux distributions (specifically [ RPM-based and Debian-based distribution-compatible](https://en.wikipedia.org/wiki/List_of_Linux_distributions)), macOS, and Windows (see [binary distribution](#binary-distribution-experimental) below) -- most users wishing to run WRF on their system can simply download the pre-compiled binaries without the need of building from source. Alternately, to build WRF from source, please refer to the [source distribution](#source-distribution) section below. HPC users, or users seeking to run WRF in the 'most optimal' configuration for their system, are advised to build WRF-CMake from source.
+The installation of WRF-CMake or WPS-CMake is straightforward thanks to the downloadable pre-built binaries for most Linux distributions (specifically [ RPM-based and Debian-based distribution-compatible](https://en.wikipedia.org/wiki/List_of_Linux_distributions)), macOS, and Windows (see [binary distribution](#binary-distribution-experimental) below) -- most users wishing to run WRF on their system can simply download the pre-compiled binaries without the need of building from source. Alternately, you can install WRF-CMake or WPS-CMake using the Homebrew/Linuxbrew package manager or by building and installing the software from source, please refer to the build and install [manually from source](#manually-from-source) and [Using Homebrew or Linuxbrew](using-homebrew-or-linuxbrew) section below.
+
+Please note that HPC users, or users seeking to run WRF in the 'most optimal' configuration for their system, are advised to build WRF-CMake manually from source or using the Homebrew/Linuxbrew package manager.
+
+
+### Manually from source
+To build and install WRF-CMake or WPS-CMake manually from source, see [this page](doc/cmake/INSTALL.md).
+
+### Using Homebrew or Linuxbrew
+WRF-CMake and WPS-CMake can be built and installed using [Homebrew](https://docs.brew.sh/Installation) (macOS) or [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux#install) (Linux) with the following commands:
+
+``` bash
+brew tap wrf-cmake/wrf && brew install wrf
+brew tap wrf-cmake/wps && brew install wps
+```
 
 
 ### Binary distribution (Experimental)
@@ -47,10 +78,35 @@ If you want to launch WRF-CMake and WPS-CMake built in `dmpar` to run on multipl
 - On Linux, use your package manager to download mpich (version ≥ 3.0.4). E.g. `sudo apt-get update && sudo apt-get install mpich` on Debian-based systems or `sudo yum install mpich` on RPM-based system like CentOS.
 
 
-### Source distribution
-To build WRF-CMake from source, see [this page](doc/cmake/INSTALL.md).
+## Documentation
 
-## Testing
+- For the WRF model technical documentation, please refer to [A Description of the Advanced Research WRF Version 3](https://opensky.ucar.edu/islandora/object/technotes%3A500/datastream/PDF/view).
+- For the WRF model user documentation, please refer to [The Advanced Research WRF version 4 Modeling System User’s Guide](http://www2.mmm.ucar.edu/wrf/users/docs/user_guide_v4/contents.html).
+
+## Example usage
+
+If you are a complete beginner, we recommend going [trough the basics](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/Basics/index.php) or [running the case studies](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/CASES/index.php) as described in the [WRF-ARW Online Tutorial](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/).
+
+If you have already used WRF/WPS before and you just want a quick tutorial to go over the main steps, we have put together a very basic one on our sister-project's website [GIS4WRF](https://gis4wrf.github.io/). You can follow the step-by-step tutorial [here](https://gis4wrf.github.io/tutorials/).
+
+
+## How to cite
+
+When using WRF-CMake in your project or publication, please cite the model as well as the software and version number as shown in the example below. Please make sure that you reference the correct DOI when referencing the software version you are using -- for a list of versions and corresponding DOIs, please see the archived versions on Zenodo at: [TODO]
+
+*We used WRF (Skamarock et al., 2008) model, from WRF-CMake (Riechert and Meyer, 2019a), version 4.1 (Riechert and Meyer, 2019b) to [...]*
+
+The corresponding reference list should be as follows
+
+W.C. Skamarock, J.B. Klemp, J. Dudhia, D.O. Gill, D.M. Barker, M.G. Duda, X.-Y. Huang, W. Wang, J.G. Powers
+**A Description of the Advanced Research WRF Version 3**. NCAR Tech (2008). Note NCAR/TN-475+STR. https://doi.org/10.5065/D68S4MVH
+
+Riechert and Meyer, 2019a: TODO
+
+Riechert and Meyer, 2019b: TODO
+
+
+## Testing framework
 
 In our current GitHub set-up, we perform a series of compilation and regression tests at each commit using the [WRF-CMake Automated Testing Suite](https://github.com/WRF-CMake/wats) on Windows, macOS, and Linux. You can find the results of such tests [here](https://travis-ci.com/WRF-CMake), [here](https://ci.appveyor.com/project/WRF-CMake/wrf), and [here](https://ci.appveyor.com/project/WRF-CMake/wps).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please note that HPC users, or users seeking to run WRF in the 'most optimal' co
 
 
 ### Manually from source
-To build and install WRF-CMake or WPS-CMake manually from source, see [this page](doc/cmake/INSTALL.md).
+To build and install WRF-CMake or WPS-CMake manually from source, see [the install from source page](doc/cmake/INSTALL.md).
 
 ### Using Homebrew or Linuxbrew
 WRF-CMake and WPS-CMake can be built and installed using [Homebrew](https://docs.brew.sh/Installation) (macOS) or [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux#install) (Linux) with the following commands:
@@ -86,9 +86,9 @@ If you want to launch WRF-CMake and WPS-CMake built in `dmpar` to run on multipl
 
 ## Example usage
 
-If you have already used WRF/WPS before and you just want a quick tutorial to go over the main steps, we have put together a very basic tutorial on our sister-project's website [GIS4WRF](https://gis4wrf.github.io/) with step-by-step instructions [here](https://gis4wrf.github.io/tutorials/wrf-cmake/simulate-the-2018-european-heat-wave-with-wrf-cmake/).
+If you have already used WRF/WPS before and you just want a quick tutorial to go over the main steps, we have put together a very basic tutorial on our sister-project's website [GIS4WRF](https://gis4wrf.github.io/) with step-by-step instructions: [Simulate The 2018 European Heat Wave with WRF-CMake](https://gis4wrf.github.io/tutorials/wrf-cmake/simulate-the-2018-european-heat-wave-with-wrf-cmake/).
 
-Otherwise, if you are a complete beginner, we recommend going [trough the basics](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/Basics/index.php) or [running the case studies](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/CASES/index.php) as described in the [WRF-ARW Online Tutorial](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/).
+Otherwise, if you are a beginner, we recommend going [trough the basics](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/Basics/index.php) or [running the case studies](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/CASES/index.php) as described in the [WRF-ARW Online Tutorial](http://www2.mmm.ucar.edu/wrf/OnLineTutorial/).
 
 
 ## How to cite

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ To build and install WRF-CMake or WPS-CMake manually from source, see [this page
 WRF-CMake and WPS-CMake can be built and installed using [Homebrew](https://docs.brew.sh/Installation) (macOS) or [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux#install) (Linux) with the following commands:
 
 ``` bash
-brew tap wrf-cmake/wrf && brew install wrf
-brew tap wrf-cmake/wps && brew install wps
+brew tap wrf-cmake/wrf
+brew install wrf
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [Documentation](#documentation)
   - [Example usage](#example-usage)
   - [How to cite](#how-to-cite)
+  - [How to contribute](#how-to-contribute)
   - [Testing framework](#testing-framework)
   - [Changes to be upstreamed](#changes-to-be-upstreamed)
   - [Copyright and license](#copyright-and-license)
@@ -20,7 +21,7 @@ WRF-CMake adds CMake support to the latest version of the [Advanced Research Wea
 
 WRF-CMake is designed to work alongside the current releases of WRF, therefore you can still compile your code using the legacy Makefiles included in WRF and WPS for any of the currently unsupported features.
 
-For more details, please see the short summary paper [WRF-CMake: integrating CMake support into the Advanced Research WRF (ARW) modelling system](https://joss.theoj.org/papers/9a87d84b2ed00ed82a6e297a4c34b3cf) on [The Journal of Open Source Software](https://joss.theoj.org/) website.
+For more details, please see the short summary paper [WRF-CMake: integrating CMake support into the Advanced Research WRF (ARW) modelling system](https://joss.theoj.org/papers/9a87d84b2ed00ed82a6e297a4c34b3cf) on the [Journal of Open Source Software](https://joss.theoj.org/) website.
 
 ### Currently supported platforms
 
@@ -44,9 +45,9 @@ For more details, please see the short summary paper [WRF-CMake: integrating CMa
 
 ## Installation
 
-The installation of WRF-CMake or WPS-CMake is straightforward thanks to the downloadable pre-built binaries for most Linux distributions (specifically [ RPM-based and Debian-based distribution-compatible](https://en.wikipedia.org/wiki/List_of_Linux_distributions)), macOS, and Windows (see [binary distribution](#binary-distribution-experimental) below) -- most users wishing to run WRF on their system can simply download the pre-compiled binaries without the need of building from source. Alternately, you can install WRF-CMake or WPS-CMake using the Homebrew/Linuxbrew package manager or by building and installing the software from source, please refer to the build and install [manually from source](#manually-from-source) and [Using Homebrew or Linuxbrew](using-homebrew-or-linuxbrew) section below.
+The installation of WRF-CMake or WPS-CMake is straightforward thanks to the downloadable pre-built binaries for most Linux distributions (specifically [ RPM-based and Debian-based distribution-compatible](https://en.wikipedia.org/wiki/List_of_Linux_distributions)), macOS, and Windows (see [binary distribution](#binary-distribution-experimental) below) -- most users wishing to run WRF on their system can simply download the pre-compiled binaries without the need to build from source. Alternately, you can install WRF-CMake or WPS-CMake using the Homebrew/Linuxbrew package manager, or by building and installing the software from source -- please refer to the build and install [manually from source](#manually-from-source) and [using Homebrew or Linuxbrew](#using-homebrew-or-linuxbrew) section below.
 
-Please note that HPC users, or users seeking to run WRF in the 'most optimal' configuration for their system, are advised to build WRF-CMake manually from source or using the Homebrew/Linuxbrew package manager.
+Please note that HPC users, or users seeking to run WRF in the 'most optimal' configuration for their system are advised to build WRF-CMake manually from source or to use the Homebrew/Linuxbrew package manager.
 
 
 ### Manually from source
@@ -57,7 +58,7 @@ WRF-CMake and WPS-CMake can be built and installed using [Homebrew](https://docs
 
 ``` bash
 brew tap wrf-cmake/wrf
-brew install wrf
+brew install wrf -v
 ```
 
 
@@ -106,6 +107,9 @@ The corresponding reference list should be as follows
 **A Description of the Advanced Research WRF Version 3**. NCAR Tech (2008). Note NCAR/TN-475+STR. https://doi.org/10.5065/D68S4MVH
 
 
+## How to contribute
+
+If you are looking to contribute, please read our [Contributors' guide](CONTRIBUTING.md) for details.
 
 
 ## Testing framework


### PR DESCRIPTION
This PR adds links to documentation and tutorials as requested in #24 and tries to simplify the README.

NOTE: we may want to merge this in if/once the paper is accepted.