### PR TITLE
Merge 4.1.5

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-WRF Model Version 4.1.4
+WRF Model Version 4.1.5
 
 http://www2.mmm.ucar.edu/wrf/users/
 

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -437,8 +437,8 @@ BENCH_START(surf_driver_tim)
 
 !gmm halo of wtd and riverflow for leafhydro
 #ifdef DM_PARALLEL
-  IF ( config_flags%sf_surface_physics.eq.NOAHMPSCHEME ) THEN
-       IF ( config_flags%opt_run.eq.5.and.mod(grid%itimestep,grid%STEPWTD).eq.0 )  THEN
+  IF ( ( config_flags%sf_surface_physics.EQ.NOAHMPSCHEME ) .and. ( config_flags%opt_run.EQ.5 ) ) THEN
+       IF ( mod(grid%itimestep,grid%STEPWTD).EQ.0 )  THEN
 #     include "HALO_EM_HYDRO_NOAHMP.inc"
        ENDIF
   ENDIF

--- a/inc/version_decl
+++ b/inc/version_decl
@@ -1,1 +1,1 @@
-   CHARACTER (LEN=*), PARAMETER :: release_version = 'V4.1.4'
+   CHARACTER (LEN=*), PARAMETER :: release_version = 'V4.1.5'

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -3103,7 +3103,8 @@ CONTAINS
 	 
 	 ENDIF 
 
-  if(iopt_run.eq.5.and.mod(itimestep,STEPWTD).eq.0)then
+  IF ( iopt_run .EQ. 5 ) THEN
+      IF ( MOD(itimestep,STEPWTD) .EQ. 0 ) THEN ! STEPWTD always and only non-zero for iopt_run == 5
            CALL wrf_debug( 100, 'calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers
@@ -3118,7 +3119,8 @@ CONTAINS
                                   ims,ime, jms,jme, kms,kme,                             &
                                   i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte )
 
-  endif
+      ENDIF
+  ENDIF
 
          call seaice_noah( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &
               &            SEAICE_THICKNESS_DEFAULT, SEAICE_SNOWDEPTH_OPT,             &


### PR DESCRIPTION
Note that the only [code changes](https://github.com/wrf-model/WRF/compare/v4.1.4...v4.1.5) from upstream are compiler related and had already been applied in WRF-CMake, hence WRF-CMake 4.1.5 is equal to 4.1.4, modulo formatting and bumping of version number.