### PR TITLE
Include Ninja build instructions (Closes #52) [skip ci]

### DIFF
--- a/azure-pipelines-full.yml
+++ b/azure-pipelines-full.yml
@@ -8,8 +8,7 @@ trigger:
     - wrf-cmake
   paths:
     exclude:
-    - 'doc/'
-    - 'README*'
+    - '**/*.md'
 
 # Run every week even if there are no code changes.
 # Catches any problems due to new dependency versions from package managers.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,7 @@ trigger:
     - wrf-cmake
   paths:
     exclude:
-    - 'doc/'
-    - 'README*'
+    - '**/*.md'
 pr: none
 
 jobs:

--- a/doc/cmake/INSTALL.md
+++ b/doc/cmake/INSTALL.md
@@ -21,12 +21,11 @@ The following libraries are required on your system to install WRF-CMake from so
 
 | Original      | CMake               |
 | ------------- | ------------------- |
-| `./configure` | `cmake ..`          |
-| `./compile`   | `cmake --build .`   |
-| -             | `cmake --install .` |
+| `./configure` | `cmake ...`          |
+| `./compile`   | `cmake --install .` |
 
 Further notes:
-- `cmake --install` is available from CMake version 3.15. For older versions use `cmake --build . --target install` instead.
+- `cmake --install` is available from CMake version 3.15. For older CMake versions use `cmake --target install` instead.
 - The [Ninja](https://ninja-build.org/) generator needs to be specified at configure time with the `-G` option, i.e. `-GNinja`.
 - The original build system uses a series of terminal prompts when running `./configure` whereas for CMake any non-default options need to be specified as command-line arguments.
 - If you change any registry files, then just re-run `cmake --install .`.
@@ -39,10 +38,9 @@ git clone https://github.com/WRF-CMake/wrf.git
 cd wrf
 mkdir build && cd build
 cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..
-cmake --build .
 cmake --install .
 ```
-where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. If your system has enough memory you can enable parallel compilation with `cmake --build . -- -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. If your system has enough memory you can enable parallel compilation with `cmake --install . -- -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 #### Note for HPC users relying on the Modules package
 If you are using `modules` for the dynamic modification of the user's environment via modulefiles, you will need to specify the path to the NetCDF manually _after_ loading all the libraries required to compile WRF/WPS. For example:
@@ -75,11 +73,10 @@ git clone https://github.com/WRF-CMake/wrf.git
 cd WRF
 mkdir build && cd build
 cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..
-cmake --build .
 cmake --install .
 ```
 The folder `<install_directory>` now contains the WRF installation and is ready to use.
-If your system has enough memory you can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+If your system has enough memory you can enable parallel compilation with `cmake --install . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 #### Build WRF-CMake with MPI support
 Open an MSYS2 **MinGW 64-bit** shell and run:
@@ -90,11 +87,10 @@ mkdir build && cd build
 cmake -GNinja -DMODE=dmpar -DCMAKE_INSTALL_PREFIX=<install_directory> \
     -DMPI_INCLUDE_PATH=$MINGW_PREFIX/include -DMPI_C_LIBRARY="$MSMPI_LIB64/msmpi.lib" \
     -DMPI_Fortran_LIBRARY="$MSMPI_LIB64/msmpifec.lib" ..
-cmake --build .
 cmake --install .
 ```
 The folder `<install_directory>` now contains the WRF installation and is ready to use.
-If your system has enough memory you can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+If your system has enough memory you can enable parallel compilation with `cmake --install . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 ### WRF-CMake options
 By default WRF-CMake will compile in `serial` mode with `basic` nesting option. You can change this by specifying the option (or flag) at configure time. The general syntax for specifying an option in CMake is `-D<flag_name>=<flag_value>` where `<flag_name>` is the option/flag name and `<flag_value>` is the option/flag value. The following options can be specified when configuring WRF-CMake:
@@ -118,7 +114,6 @@ For example, to build and install WRF-CMake on Linux/macOS by setting all the av
 CC=gcc FC=gfortran cmake -GNinja -DCMAKE_INSTALL_PREFIX=~/apps/WRF \
     -DCMAKE_BUILD_TYPE=Release -DMODE=dmpar -DNESTING=basic \
     -DENABLE_GRIB1=ON -DENABLE_GRIB2=ON  ..
-cmake --build .
 cmake --install .
 ```
 
@@ -130,12 +125,11 @@ If you intend to run real cases in WRF-CMake, you will also need to compile WPS-
 git clone https://github.com/WPS-CMake/WPS.git
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=<install_directory> -DWRF_DIR=<wrf_cmake_build_directory> ..
-cmake --build .
 cmake --install .
 ```
 
 where `<install_directory>` is the directory where to install WPS and `<wrf_cmake_build_directory>` is the path to the `build` folder of WRF (relative or absolute). To specify more options, please see the [WPS-CMake options](#wps-cmake-options).
-You can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+You can enable parallel compilation with `cmake --install . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 ### WPS-CMake options
 

--- a/doc/cmake/INSTALL.md
+++ b/doc/cmake/INSTALL.md
@@ -29,7 +29,7 @@ Further notes:
 - `cmake --install` is available from CMake version 3.15. For older versions use `cmake --build . --target install` instead.
 - The [Ninja](https://ninja-build.org/) generator needs to be specified at configure time with the `-G` option, i.e. `-GNinja`.
 - The original build system uses a series of terminal prompts when running `./configure` whereas for CMake any non-default options need to be specified as command-line arguments.
-- If you change any registry files, then just re-run `cmake --build .`.
+- If you change any registry files, then just re-run `cmake --install .`.
 
 ### On Linux and macOS
 The general commands to download, configure and install WRF-CMake on Linux and macOS are:
@@ -42,7 +42,7 @@ cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..
 cmake --build .
 cmake --install .
 ```
-where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. If your system has enough memory you can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. If your system has enough memory you can enable parallel compilation with `cmake --build . -- -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 #### Note for HPC users relying on the Modules package
 If you are using `modules` for the dynamic modification of the user's environment via modulefiles, you will need to specify the path to the NetCDF manually _after_ loading all the libraries required to compile WRF/WPS. For example:

--- a/doc/cmake/INSTALL.md
+++ b/doc/cmake/INSTALL.md
@@ -25,7 +25,7 @@ The following libraries are required on your system to install WRF-CMake from so
 | `./compile`   | `cmake --install .` |
 
 Further notes:
-- `cmake --install` is available from CMake version 3.15. For older CMake versions use `cmake --target install` instead.
+- `cmake --install` is available from CMake version 3.15. For older CMake versions use `cmake --build . --target install` instead.
 - The [Ninja](https://ninja-build.org/) generator needs to be specified at configure time with the `-G` option, i.e. `-GNinja`.
 - The original build system uses a series of terminal prompts when running `./configure` whereas for CMake any non-default options need to be specified as command-line arguments.
 - If you change any registry files, then just re-run `cmake --install .`.
@@ -40,7 +40,7 @@ mkdir build && cd build
 cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..
 cmake --install .
 ```
-where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. If your system has enough memory you can enable parallel compilation with `cmake --install . -- -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. By default Ninja runs in parallel. If your system does not have enough memory you can restrict the number of parallel processes with the `-j` flag. For example, to compile with 2 parallel processes run `cmake --install . -j 2`.
 
 #### Note for HPC users relying on the Modules package
 If you are using `modules` for the dynamic modification of the user's environment via modulefiles, you will need to specify the path to the NetCDF manually _after_ loading all the libraries required to compile WRF/WPS. For example:
@@ -76,7 +76,7 @@ cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..
 cmake --install .
 ```
 The folder `<install_directory>` now contains the WRF installation and is ready to use.
-If your system has enough memory you can enable parallel compilation with `cmake --install . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+By default Ninja runs in parallel. If your system does not have enough memory you can restrict the number of parallel processes with the `-j` flag. For example, to compile with 2 parallel processes run `cmake --install . -j 2`.
 
 #### Build WRF-CMake with MPI support
 Open an MSYS2 **MinGW 64-bit** shell and run:
@@ -90,7 +90,7 @@ cmake -GNinja -DMODE=dmpar -DCMAKE_INSTALL_PREFIX=<install_directory> \
 cmake --install .
 ```
 The folder `<install_directory>` now contains the WRF installation and is ready to use.
-If your system has enough memory you can enable parallel compilation with `cmake --install . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+By default Ninja runs in parallel. If your system does not have enough memory you can restrict the number of parallel processes with the `-j` flag. For example, to compile with 2 parallel processes run `cmake --install . -j 2`.
 
 ### WRF-CMake options
 By default WRF-CMake will compile in `serial` mode with `basic` nesting option. You can change this by specifying the option (or flag) at configure time. The general syntax for specifying an option in CMake is `-D<flag_name>=<flag_value>` where `<flag_name>` is the option/flag name and `<flag_value>` is the option/flag value. The following options can be specified when configuring WRF-CMake:
@@ -129,7 +129,6 @@ cmake --install .
 ```
 
 where `<install_directory>` is the directory where to install WPS and `<wrf_cmake_build_directory>` is the path to the `build` folder of WRF (relative or absolute). To specify more options, please see the [WPS-CMake options](#wps-cmake-options).
-You can enable parallel compilation with `cmake --install . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 ### WPS-CMake options
 

--- a/doc/cmake/INSTALL.md
+++ b/doc/cmake/INSTALL.md
@@ -13,20 +13,23 @@ brew install wrf-cmake -v
 For more flexibility, e.g. when changing the registry, see the manual build instructions below.
 
 ## Install dependencies
-The following libraries are required on your system to install WRF-CMake from source: [Git](https://git-scm.com/), [JasPer](https://www.ece.uvic.ca/~frodo/jasper/), [libpng](http://www.libpng.org/pub/png/libpng.html), [libjpeg](http://libjpeg.sourceforge.net/), [zlib](https://zlib.net/), [HDF5](https://support.hdfgroup.org/HDF5/), [NetCDF-C](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), [NetCDF-Fortran](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), and MPI (required if building in `dmpar` or `dm_sm` mode). The above libraries are most likely available from your system's package manager (e.g. APT, yum, Homebrew, etc.). If you do not have the latest version of these libraries installed on your system, please see [this page](LIBS.md).
+The following libraries are required on your system to install WRF-CMake from source: [CMake](https://cmake.org/), [Ninja](https://ninja-build.org/), [Git](https://git-scm.com/), [JasPer](https://www.ece.uvic.ca/~frodo/jasper/), [libpng](http://www.libpng.org/pub/png/libpng.html), [libjpeg](http://libjpeg.sourceforge.net/), [zlib](https://zlib.net/), [HDF5](https://support.hdfgroup.org/HDF5/), [NetCDF-C](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), [NetCDF-Fortran](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), and MPI (required if building in `dmpar` or `dm_sm` mode). The above libraries are most likely available from your system's package manager (e.g. APT, yum, Homebrew, etc.). If you do not have the latest version of these libraries installed on your system, please see [this page](LIBS.md).
 
 ## Build and Install WRF-CMake
 
 ### Transition from original build system
 
-| Original      | CMake          |
-| ------------- | -------------- |
-| `./configure` | `cmake ...`    |
-| `./compile`   | `make install` |
+| Original      | CMake               |
+| ------------- | ------------------- |
+| `./configure` | `cmake ..`          |
+| `./compile`   | `cmake --build .`   |
+| -             | `cmake --install .` |
 
 Further notes:
+- `cmake --install` is available from CMake version 3.15. For older versions use `cmake --build . --target install` instead.
+- The [Ninja](https://ninja-build.org/) generator needs to be specified at configure time with the `-G` option, i.e. `-GNinja`.
 - The original build system uses a series of terminal prompts when running `./configure` whereas for CMake any non-default options need to be specified as command-line arguments.
-- If you change any registry files, then just re-run `make install`.
+- If you change any registry files, then just re-run `cmake --build .`.
 
 ### On Linux and macOS
 The general commands to download, configure and install WRF-CMake on Linux and macOS are:
@@ -35,10 +38,11 @@ The general commands to download, configure and install WRF-CMake on Linux and m
 git clone https://github.com/WRF-CMake/wrf.git
 cd wrf
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=<install_directory> ..
-make install
+cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..
+cmake --build .
+cmake --install .
 ```
-where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. If your system has enough memory you can enable parallel compilation with `make install -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+where `<install_directory>` is the directory where to install WRF. Depending on your system's configuration, you may need to specify [WRF-CMake options](#wrf-cmake-options). If multiple compilers are available on the system, use the `CC` (C compiler) and/or `FC` (Fortran compiler) environment variables to specify them. For example, to use Intel C and Fortran compilers run `CC=icc FC=ifort cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..`. On macOS, use `CC=gcc-8 FC=gfortran-8` to use the GNU compilers installed with Homebrew. If your system has enough memory you can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 #### Note for HPC users relying on the Modules package
 If you are using `modules` for the dynamic modification of the user's environment via modulefiles, you will need to specify the path to the NetCDF manually _after_ loading all the libraries required to compile WRF/WPS. For example:
@@ -62,7 +66,7 @@ cmake -DNETCDF_DIR=<path_to_netcdf-c-dir> -DNETCDF_FORTRAN_DIR=<path_to_netcdf-f
 where `<path_to_netcdf-c-dir>` and `<path_to_netcdf-fortran-dir>` are the absolute path to your NetCDF-C and NetCDF-Fortran installation directories.
 
 ### On Windows (with MinGW-w64 and gcc/gfortran)
-Make sure you [installed all the required dependencies](README_CMAKE_LIBS.md) before continuing.
+Make sure you [installed all the required dependencies](LIBS.md) before continuing.
 
 #### Build WRF-CMake in serial mode
 Open an MSYS2 **MinGW 64-bit** shell and run:
@@ -70,11 +74,12 @@ Open an MSYS2 **MinGW 64-bit** shell and run:
 git clone https://github.com/WRF-CMake/wrf.git
 cd WRF
 mkdir build && cd build
-cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=<install_directory> ..
-make install
+cmake -GNinja -DCMAKE_INSTALL_PREFIX=<install_directory> ..
+cmake --build .
+cmake --install .
 ```
 The folder `<install_directory>` now contains the WRF installation and is ready to use.
-If your system has enough memory you can enable parallel compilation with `make install -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+If your system has enough memory you can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 #### Build WRF-CMake with MPI support
 Open an MSYS2 **MinGW 64-bit** shell and run:
@@ -82,13 +87,14 @@ Open an MSYS2 **MinGW 64-bit** shell and run:
 git clone https://github.com/WRF-CMake/wrf.git
 cd WRF
 mkdir build && cd build
-cmake -G "MSYS Makefiles" -DMODE=dmpar -DCMAKE_INSTALL_PREFIX=<install_directory> \
+cmake -GNinja -DMODE=dmpar -DCMAKE_INSTALL_PREFIX=<install_directory> \
     -DMPI_INCLUDE_PATH=$MINGW_PREFIX/include -DMPI_C_LIBRARY="$MSMPI_LIB64/msmpi.lib" \
     -DMPI_Fortran_LIBRARY="$MSMPI_LIB64/msmpifec.lib" ..
-make install
+cmake --build .
+cmake --install .
 ```
 The folder `<install_directory>` now contains the WRF installation and is ready to use.
-If your system has enough memory you can enable parallel compilation with `make install -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+If your system has enough memory you can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 ### WRF-CMake options
 By default WRF-CMake will compile in `serial` mode with `basic` nesting option. You can change this by specifying the option (or flag) at configure time. The general syntax for specifying an option in CMake is `-D<flag_name>=<flag_value>` where `<flag_name>` is the option/flag name and `<flag_value>` is the option/flag value. The following options can be specified when configuring WRF-CMake:
@@ -109,10 +115,11 @@ By default WRF-CMake will compile in `serial` mode with `basic` nesting option. 
 For example, to build and install WRF-CMake on Linux/macOS by setting all the available options and installing in `~/apps/WRF` with gcc and gfortran:
 ``` sh
 # Assumes you are in the WRF directory
-CC=gcc FC=gfortran cmake -DCMAKE_INSTALL_PREFIX=~/apps/WRF \
+CC=gcc FC=gfortran cmake -GNinja -DCMAKE_INSTALL_PREFIX=~/apps/WRF \
     -DCMAKE_BUILD_TYPE=Release -DMODE=dmpar -DNESTING=basic \
     -DENABLE_GRIB1=ON -DENABLE_GRIB2=ON  ..
-make install
+cmake --build .
+cmake --install .
 ```
 
 ## Build and Install WPS-CMake
@@ -123,11 +130,12 @@ If you intend to run real cases in WRF-CMake, you will also need to compile WPS-
 git clone https://github.com/WPS-CMake/WPS.git
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=<install_directory> -DWRF_DIR=<wrf_cmake_build_directory> ..
-make install
+cmake --build .
+cmake --install .
 ```
 
 where `<install_directory>` is the directory where to install WPS and `<wrf_cmake_build_directory>` is the path to the `build` folder of WRF (relative or absolute). To specify more options, please see the [WPS-CMake options](#wps-cmake-options).
-You can enable parallel compilation with `make install -j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
+You can enable parallel compilation with `cmake --build . --j <n>` where `<n>` is the maximum number of jobs you like to run in parallel.
 
 ### WPS-CMake options
 

--- a/doc/cmake/LIBS.md
+++ b/doc/cmake/LIBS.md
@@ -4,11 +4,13 @@ The following libraries are required on your system to install WRF-CMake from so
 For the installation of libraries, we rely on your system's package managers (APT, YUM, Homebrew). We assume that you have administrative privileges on your computer. If you do not have administrative privileges you should request these libraries to be installed by your system administrator so that they can tare of this for you and manage updates on your behalf.
 
 ## Table of contents
-- [Ubuntu](#ubuntu)
+- [How to install required libraries for WRF-CMake](#how-to-install-required-libraries-for-wrf-cmake)
+  - [Table of contents](#table-of-contents)
+  - [Ubuntu](#ubuntu)
     - [16.04 LTS (Xenial)](#1604-lts-xenial)
     - [18.04 LTS (Bionic)](#1804-lts-bionic)
-- [macOS](#macOS)
-- [Windows](#windows)
+  - [macOS](#macos)
+  - [Windows](#windows)
     - [Microsoft MPI support](#microsoft-mpi-support)
 
 ## Ubuntu
@@ -135,6 +137,5 @@ mpiexec -n 2 example1.exe
 mpiexec -n 2 example2.exe
 ```
 
-If everything went OK, you can now build WRF with MPI. You can go back to [Build and Install WRF-CMake].
-
-[Build and Install WRF-CMake]:INSTALL.md#build-and-install-wrf-cmake
+If everything went OK, you can now build WRF with MPI. You can go back to [Build and Install WRF-CMake](INSTALL.md#build-and-install-wrf-cmake
+).

--- a/doc/cmake/LIBS.md
+++ b/doc/cmake/LIBS.md
@@ -1,11 +1,10 @@
 # How to install required libraries for WRF-CMake
-The following libraries are required on your system to install WRF-CMake from source: [Git](https://git-scm.com/), [JasPer](https://www.ece.uvic.ca/~frodo/jasper/), [libpng](http://www.libpng.org/pub/png/libpng.html), [libjpeg](http://libjpeg.sourceforge.net/), [zlib](https://zlib.net/), [HDF5](https://support.hdfgroup.org/HDF5/), [NetCDF-C](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), [NetCDF-Fortran](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), and MPI (required if building in `dmpar` or `dm_sm` mode).
+The following libraries are required on your system to install WRF-CMake from source: [CMake](https://cmake.org/), [Ninja](https://ninja-build.org/), [Git](https://git-scm.com/), [JasPer](https://www.ece.uvic.ca/~frodo/jasper/), [libpng](http://www.libpng.org/pub/png/libpng.html), [libjpeg](http://libjpeg.sourceforge.net/), [zlib](https://zlib.net/), [HDF5](https://support.hdfgroup.org/HDF5/), [NetCDF-C](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), [NetCDF-Fortran](https://www.unidata.ucar.edu/downloads/netcdf/index.jsp), and MPI (required if building in `dmpar` or `dm_sm` mode).
 
 For the installation of libraries, we rely on your system's package managers (APT, YUM, Homebrew). We assume that you have administrative privileges on your computer. If you do not have administrative privileges you should request these libraries to be installed by your system administrator so that they can tare of this for you and manage updates on your behalf.
 
 ## Table of contents
 - [Ubuntu](#ubuntu)
-    - [14.04 LTS (Trusty)](#1404-lts-trusty)
     - [16.04 LTS (Xenial)](#1604-lts-xenial)
     - [18.04 LTS (Bionic)](#1804-lts-bionic)
 - [macOS](#macOS)
@@ -14,25 +13,16 @@ For the installation of libraries, we rely on your system's package managers (AP
 
 ## Ubuntu
 
-### 14.04 LTS (Trusty)
-To install all the required dependencies, including support for MPI, run the following commands from your terminal prompt:
-
-```sh
-sudo apt-get update && sudo apt-get upgrade -y
-sudo apt-get install -y git cmake3 gfortran libnetcdf-dev libpng-dev libjasper-dev libmpich-dev
-```
-
-After the installtion is complete, you can go back to [Build and Install WRF-CMake].
-
 ### 16.04 LTS (Xenial)
 To install all the required dependencies, including support for MPI, run the following commands from your terminal prompt:
 
 ```sh
 sudo apt-get update && sudo apt-get upgrade -y
-sudo apt-get install -y git cmake gfortran libnetcdf-dev libnetcdff-dev libpng-dev libjasper-dev libjpeg-dev zlib1g-dev libmpich-dev
+sudo apt-get install -y git cmake ninja-build gfortran libnetcdf-dev libnetcdff-dev libpng-dev libjasper-dev libjpeg-dev zlib1g-dev libmpich-dev
 ```
 
 After the installtion is complete, you can go back to [Build and Install WRF-CMake].
+
 
 ### 18.04 LTS (Bionic)
 
@@ -40,7 +30,7 @@ To install all the required dependencies except for JasPer (installed manually, 
 
 ```sh
 sudo apt-get update && sudo apt-get upgrade -y
-sudo apt-get install -y git cmake gfortran libnetcdf-dev libnetcdff-dev libpng-dev libjpeg-dev zlib1g-dev libmpich-dev
+sudo apt-get install -y git cmake ninja-build gfortran libnetcdf-dev libnetcdff-dev libpng-dev libjpeg-dev zlib1g-dev libmpich-dev
 ```
 
 NOTE: `libjasper-dev` is currently not provided though APT and you will need to install it from source. For the moment, you can simply [download the latest version of JasPer](https://www.ece.uvic.ca/~frodo/jasper/#download) and install it manually from source. To do this you can use the following commands:
@@ -62,7 +52,7 @@ On macOS, we can use Homebrew to install the required libraries. If you do not h
 
 ```sh
 brew update
-brew install git cmake gcc netcdf jasper open-mpi
+brew install git cmake ninja gcc netcdf jasper open-mpi
 ```
 
 After the installation is complete, you can go back to [Build and Install WRF-CMake].
@@ -73,7 +63,7 @@ After the installation is complete, you can go back to [Build and Install WRF-CM
 - Inside the MSYS2 **MinGW 64-bit** shell, run `pacman -Syu`
 - Restart the shell
 - Run `pacman -Syu` again to finish upgrading
-- Run `pacman -S --noconfirm --needed make unzip git mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-cmake mingw64/mingw-w64-x86_64-portablexdr`
+- Run `pacman -S --noconfirm --needed make mingw-w64-x86_64-ninja unzip git mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-portablexdr`
 - Run `pacman -S --noconfirm --needed mingw-w64-x86_64-libpng mingw-w64-x86_64-libjpeg-turbo mingw-w64-x86_64-jasper` (for WPS; or WRF with GRIB 2 support)
 - Run `pacman -S --noconfirm --needed mingw-w64-x86_64-hdf5 mingw-w64-x86_64-libtool tar` (only needed for temporary netCDF compilation below)
 

--- a/doc/cmake/LIBS.md
+++ b/doc/cmake/LIBS.md
@@ -137,5 +137,6 @@ mpiexec -n 2 example1.exe
 mpiexec -n 2 example2.exe
 ```
 
-If everything went OK, you can now build WRF with MPI. You can go back to [Build and Install WRF-CMake](INSTALL.md#build-and-install-wrf-cmake
-).
+If everything went OK, you can now build WRF with MPI. You can go back to [Build and Install WRF-CMake].
+
+[Build and Install WRF-CMake]:INSTALL.md#build-and-install-wrf-cmake


### PR DESCRIPTION
This PR updates the docs to include instructions for building with Ninja (#52) and removes instructions about Ubuntu 14.04.